### PR TITLE
Fix examples

### DIFF
--- a/examples/hello/index.html
+++ b/examples/hello/index.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" href="/examples/ui.css" />
     <script src="/examples/ui.js"></script>
-    <script src="/dist/bundle.js"></script>
+    <script src="/dist/index.js"></script>
     <script id="example">
       const { AudioGraph, build } = helicon;
       window.ag = new AudioGraph(

--- a/examples/nodeExtension/index.html
+++ b/examples/nodeExtension/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <link rel="stylesheet" href="/examples/ui.css" />
-    <script src="/dist/bundle.js"></script>
     <script src="/examples/ui.js"></script>
+    <script src="/dist/index.js"></script>
     <script id="processor" type="text/template">
       registerProcessor(
         'WhiteNoiseProcessor',
@@ -18,7 +18,7 @@
       );
     </script>
     <script id="example">
-      const { AudioGraph, build } = audiograph;
+      const { AudioGraph, build } = helicon;
 
       const extensions = [
         {


### PR DESCRIPTION
This PR replaces `bundle.js` with `index.js` and `audiograph` with `helicon`. These changes were required to get the examples working on my machine.

I have also swapped two lines to improve consistency in ordering.